### PR TITLE
Two-factor authentication support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/mocha": "^5.2.6",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
+    "2fa-util": "^1.1.1",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.22.1",
     "mocha": "^6.0.2",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -13,7 +13,7 @@ import {NTBBLadder} from './ladder';
 import {Replays, md5} from './replays';
 import {toID} from './server';
 import * as tables from './tables';
-const {generateSecret} = require('2fa-util');
+import {generateSecret} = '2fa-util';
 
 // shamelessly stolen from PS main
 function bash(command: string, cwd?: string): Promise<[number, string, string]> {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -99,7 +99,7 @@ export const actions: {[k: string]: QueryHandler} = {
 			);
 		}
 		
-		const alreadyhas2fa = await tables.users.get(['mfaenabled'], userid).catch(() => []);
+		const alreadyhas2fa = await tables.users.get(['mfaenabled'], userid).catch(() => {});
 		if (alreadyhas2fa?.mfaenabled === 1) return false;
 
 		const token = await generateSecret(userid, 'Pokemon Showdown!')

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -82,7 +82,6 @@ export const actions: {[k: string]: QueryHandler} = {
 		const res: {[k: string]: any} = {};
 		const curuser = this.user;
 		let userid = '';
-		curuser.login('fart');
 		if (curuser.loggedin) {
 			res.username = curuser.name;
 			userid = curuser.id;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -81,6 +81,7 @@ export const actions: {[k: string]: QueryHandler} = {
 		const challengeprefix = this.verifyCrossDomainRequest();
 		const res: {[k: string]: any} = {};
 		const curuser = this.user;
+		
 		let userid = '';
 		if (curuser.loggedin) {
 			res.username = curuser.name;
@@ -97,6 +98,9 @@ export const actions: {[k: string]: QueryHandler} = {
 				userid, challengekeyid, curuser, challenge, challengeprefix
 			);
 		}
+		
+		const alreadyhas2fa = await tables.users.get(['mfaenabled'], userid).catch(() => []);
+		if (alreadyhas2fa?.mfaenabled === 1) return false;
 
 		const token = await generateSecret(userid, 'Pokemon Showdown!')
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -13,7 +13,7 @@ import {NTBBLadder} from './ladder';
 import {Replays, md5} from './replays';
 import {toID} from './server';
 import * as tables from './tables';
-import {generateSecret} = '2fa-util';
+import {generateSecret} from '2fa-util';
 
 // shamelessly stolen from PS main
 function bash(command: string, cwd?: string): Promise<[number, string, string]> {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -128,7 +128,7 @@ export const actions: {[k: string]: QueryHandler} = {
 		const challengekeyid = parseInt(params.challengekeyid) || -1;
 		let actionsuccess = await this.session.passwordVerify(params.name, params.pass);
 		if (!actionsuccess) return {actionsuccess, assertion: false};
-		actionsuccess = true;//await this.session.mfaVerify(userid, params.mfa);
+		actionsuccess = await this.session.mfaVerify(userid, params.mfa);
 		if (!actionsuccess) return {actionsuccess, assertion: false};
 		const challenge = params.challstr || "";
 		const assertion = await this.session.getAssertion(

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,7 @@ import SQL from 'sql-template-strings';
 import {toID} from './server';
 import {ladder, loginthrottle, sessions, users, usermodlog} from './tables';
 import type {User} from './user';
-const {verify} = require('2fa-util');
+import {verify} from '2fa-util';
 
 const SID_DURATION = 2 * 7 * 24 * 60 * 60;
 const LOGINTIME_INTERVAL = 24 * 60 * 60;


### PR DESCRIPTION
- [~~If converting require to import is as easy as "import {generateSecret} from '2fa-util'" I can make that change, but I am unfamiliar at the moment with how that is accomplished.~~ EDIT: Resolved.]

- [I am not sure if I should do the PR for the client patch since the dev loginserver is staff only at the moment. But here is that repo/branch: https://github.com/tmagicturtle/Pokemon-Showdown-Client/tree/patch-7] 

Requires 1 dependency: "2fa-util". It has two deps of its own, otplib and qrcode, and is a single MIT licensed file, so we can use it directly instead of requiring as a node package. But it carries much of the work - it securely generates TOTP secrets, handles verifying TOTP tokens, and generates QR codes for the end-user to scan in their 2FA app.

Functioning demonstration video: https://www.youtube.com/watch?v=znuIBtmO-R8

Lastly, I was unable to get my client/server to work nicely with cookies. In developing this, I had to cheat by forcing the user to be logged in as fart. The code as applied takes the login procedure from other methods, so it SHOULD work, but due to the aforementioned complications, it is untested.