### PR TITLE
Powerful SQL template strings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -221,7 +221,7 @@
         "@typescript-eslint/adjacent-overload-signatures": "error",
         // "@typescript-eslint/array-type": "error",
         "@typescript-eslint/consistent-type-assertions": ["error", {"assertionStyle": "as"}],
-        "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
+        "@typescript-eslint/consistent-type-definitions": "off",
         "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}],
         "@typescript-eslint/member-delimiter-style": "error",
         "@typescript-eslint/no-parameter-properties": "error",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -8,7 +8,6 @@ import {Config} from './config-loader';
 import {ActionError, Dispatcher, QueryHandler} from './dispatcher';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
-import {SQL} from './database';
 import {NTBBLadder} from './ladder';
 import {Replays, md5} from './replays';
 import {toID} from './server';
@@ -165,9 +164,9 @@ export const actions: {[k: string]: QueryHandler} = {
 			return {actionsuccess: false};
 		}
 
-		await tables.userstats.insert({
+		await tables.userstats.replace({
 			serverid: server.id, date, usercount,
-		}, SQL`ON DUPLICATE KEY UPDATE \`date\`= ${date}, \`usercount\`= ${usercount}`);
+		});
 
 		if (server.id === Config.mainserver) {
 			await tables.userstatshistory.insert({date, usercount});

--- a/src/ladder.ts
+++ b/src/ladder.ts
@@ -7,7 +7,6 @@
 import {time} from './session';
 import {toID} from './server';
 import {ladder} from './tables';
-import {SQL} from './database';
 import type {User} from './user';
 
 export interface LadderEntry {
@@ -65,16 +64,16 @@ export class NTBBLadder {
 	clearRating(name: string | User | FakeUser) {
 		return ladder.updateOne({
 			elo: 1000, col1: 0, w: 0, l: 0, t: 0,
-		}, SQL`WHERE userid = ${toID(name)} AND formatid = ${this.formatid}`);
+		})`WHERE userid = ${toID(name)} AND formatid = ${this.formatid}`;
 	}
 	clearWL(name: User | string) {
 		return ladder.updateOne({
 			w: 0, l: 0, t: 0,
-		}, SQL`WHERE userid = ${toID(name)} AND formatid = ${this.formatid}`);
+		})`WHERE userid = ${toID(name)} AND formatid = ${this.formatid}`;
 	}
 	async getRating(user: User | FakeUser, create = false) {
 		if (!user.rating) {
-			const data = await ladder.selectOne(null, SQL`WHERE userid = ${user.id} AND formatid = ${this.formatid}`);
+			const data = await ladder.selectOne()`WHERE userid = ${user.id} AND formatid = ${this.formatid}`;
 
 			if (!data) {
 				if (!create) {
@@ -114,7 +113,7 @@ export class NTBBLadder {
 	}
 	async getAllRatings(user: User | FakeUser) {
 		if (!user.ratings) {
-			const res = await ladder.selectAll(null, SQL`WHERE userid = ${user.id}`);
+			const res = await ladder.selectAll()`WHERE userid = ${user.id}`;
 			if (!res) {
 				return false;
 			}
@@ -149,11 +148,11 @@ export class NTBBLadder {
 				// an indexed query for additional rows and filter them down further. This is obviously *not* guaranteed
 				// to return exactly $limit results, but should be 'good enough' in practice.
 				const overfetch = limit * 2;
-				res = await ladder.query(SQL`SELECT * FROM
+				res = await ladder.query()`SELECT * FROM
 					(SELECT * FROM ntbb_ladder WHERE formatid = ${this.formatid} ORDER BY elo DESC LIMIT ${limit})
-					AS unusedalias WHERE userid LIKE ${prefix} LIMIT ${overfetch}`);
+					AS unusedalias WHERE userid LIKE ${prefix} LIMIT ${overfetch}`;
 			} else {
-				res = await ladder.selectAll(null, SQL`WHERE formatid = ${this.formatid} ORDER BY elo DESC`);
+				res = await ladder.selectAll()`WHERE formatid = ${this.formatid} ORDER BY elo DESC`;
 			}
 
 			for (const row of res) {
@@ -177,7 +176,7 @@ export class NTBBLadder {
 		return top;
 	}
 	clearAllRatings() {
-		return ladder.deleteAll(SQL`WHERE formatid = ${this.formatid}`);
+		return ladder.deleteAll()`WHERE formatid = ${this.formatid}`;
 	}
 
 	async saveRating(user: User | FakeUser) {

--- a/src/ladder.ts
+++ b/src/ladder.ts
@@ -65,16 +65,16 @@ export class NTBBLadder {
 	clearRating(name: string | User | FakeUser) {
 		return ladder.updateOne({
 			elo: 1000, col1: 0, w: 0, l: 0, t: 0,
-		}, SQL`userid = ${toID(name)} AND formatid = ${this.formatid}`);
+		}, SQL`WHERE userid = ${toID(name)} AND formatid = ${this.formatid}`);
 	}
 	clearWL(name: User | string) {
 		return ladder.updateOne({
 			w: 0, l: 0, t: 0,
-		}, SQL`userid = ${toID(name)} AND formatid = ${this.formatid}`);
+		}, SQL`WHERE userid = ${toID(name)} AND formatid = ${this.formatid}`);
 	}
 	async getRating(user: User | FakeUser, create = false) {
 		if (!user.rating) {
-			const data = await ladder.selectOne(null, SQL`userid = ${user.id} AND formatid = ${this.formatid}`);
+			const data = await ladder.selectOne(null, SQL`WHERE userid = ${user.id} AND formatid = ${this.formatid}`);
 
 			if (!data) {
 				if (!create) {
@@ -84,7 +84,7 @@ export class NTBBLadder {
 				const res = await ladder.insert({
 					formatid: this.formatid, username: user.name, userid: user.id,
 					rptime: rp, rpdata: '', col1: 0,
-				}, SQL``, false);
+				});
 				user.rating = {
 					entryid: res.insertId,
 					formatid: this.formatid,
@@ -114,7 +114,7 @@ export class NTBBLadder {
 	}
 	async getAllRatings(user: User | FakeUser) {
 		if (!user.ratings) {
-			const res = await ladder.selectAll(null, SQL`userid = ${user.id}`);
+			const res = await ladder.selectAll(null, SQL`WHERE userid = ${user.id}`);
 			if (!res) {
 				return false;
 			}
@@ -149,13 +149,11 @@ export class NTBBLadder {
 				// an indexed query for additional rows and filter them down further. This is obviously *not* guaranteed
 				// to return exactly $limit results, but should be 'good enough' in practice.
 				const overfetch = limit * 2;
-				const query = SQL`SELECT * FROM `;
-				query.append(SQL`(SELECT * FROM \`ntbb_ladder\` WHERE \`formatid\` = ${this.formatid} `);
-				query.append(SQL`ORDER BY \`elo\` DESC LIMIT ${limit})`);
-				query.append(SQL`AS \`unusedalias\` WHERE \`userid\` LIKE ${prefix} LIMIT ${overfetch}`);
-				res = await ladder.query(query);
+				res = await ladder.query(SQL`SELECT * FROM
+					(SELECT * FROM ntbb_ladder WHERE formatid = ${this.formatid} ORDER BY elo DESC LIMIT ${limit})
+					AS unusedalias WHERE userid LIKE ${prefix} LIMIT ${overfetch}`);
 			} else {
-				res = await ladder.selectAll(null, SQL`formatid = ${this.formatid} ORDER BY elo DESC`);
+				res = await ladder.selectAll(null, SQL`WHERE formatid = ${this.formatid} ORDER BY elo DESC`);
 			}
 
 			for (const row of res) {
@@ -179,7 +177,7 @@ export class NTBBLadder {
 		return top;
 	}
 	clearAllRatings() {
-		return ladder.deleteAll(SQL`formatid = ${this.formatid}`);
+		return ladder.deleteAll(SQL`WHERE formatid = ${this.formatid}`);
 	}
 
 	async saveRating(user: User | FakeUser) {

--- a/src/replays.ts
+++ b/src/replays.ts
@@ -73,7 +73,7 @@ export const Replays = new class {
 			rating,
 			inputlog: Array.isArray(inputlog) ? inputlog.join('\n') : inputlog as string,
 			private: isPrivate,
-		}, SQL``);
+		});
 		return !!out.affectedRows;
 	}
 
@@ -93,21 +93,21 @@ export const Replays = new class {
 		for (const player of ['p1', 'p2'] as const) {
 			if (replay[player].startsWith('!')) replay[player] = replay[player].slice(1);
 		}
-		await replays.query(SQL`UPDATE ps_replays SET views = views + 1 WHERE id = ${replay.id}`);
+		await replays.update(replay.id, {views: SQL`views + 1`});
 
 		return replay;
 	}
 
 	async edit(replay: ReplayData) {
 		if (replay.private === 3) {
-			await replays.updateOne({private: 3, password: null}, SQL`id = ${replay.id}`);
+			await replays.update(replay.id, {private: 3, password: null});
 		} else if (replay.private === 2) {
-			await replays.updateOne({private: 1, password: null}, SQL`id = ${replay.id}`);
+			await replays.update(replay.id, {private: 1, password: null});
 		} else if (replay.private) {
 			if (!replay.password) replay.password = this.generatePassword();
-			await replays.updateOne({private: 1, password: replay.password}, SQL`id = ${replay.id}`);
+			await replays.update(replay.id, {private: 1, password: replay.password});
 		} else {
-			await replays.updateOne({private: 1, password: null}, SQL`id = ${replay.id}`);
+			await replays.update(replay.id, {private: 1, password: null});
 		}
 	}
 
@@ -131,67 +131,61 @@ export const Replays = new class {
 			if (args.username2) {
 				const userid2 = toID(args.username2);
 				if (format) {
-					const query = SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays `;
-					query.append(`FORCE INDEX (p1) `);
-					query.append(SQL`WHERE private = ${isPrivate} AND p1id = ${userid} `);
-					query.append(SQL`AND p2id = ${userid2} AND format = ${format} `);
-					query.append('ORDER BY ');
-					query.append(`${order} DESC)`);
-					query.append(' UNION ');
-					query.append(SQL`(SELECT uploadtime, id, format, p1, p2, password `);
-					query.append(SQL`FROM ps_replays FORCE INDEX (p1) `);
-					query.append(SQL`WHERE private = ${isPrivate} AND p1id = ${userid2} AND p2id = ${userid} `);
-					query.append(SQL`AND format = ${format}`);
-					query.append(` ORDER BY ${order} DESC)`);
-					query.append(` ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
-					return replays.query(query);
+					return replays.query(SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
+						FORCE INDEX (p1) 
+						WHERE private = ${isPrivate} AND p1id = ${userid} 
+						AND p2id = ${userid2} AND format = ${format} 
+						ORDER BY 
+						${order} DESC)
+						 UNION 
+						(SELECT uploadtime, id, format, p1, p2, password 
+						FROM ps_replays FORCE INDEX (p1) 
+						WHERE private = ${isPrivate} AND p1id = ${userid2} AND p2id = ${userid} 
+						AND format = ${format}
+						 ORDER BY ${order} DESC)
+						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
 				} else {
-					const query = SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays `;
-					query.append(`FORCE INDEX (p1) `);
-					query.append(SQL`WHERE private = ${isPrivate} AND p1id = ${userid} AND p2id = ${userid2}`);
-					query.append(` ORDER BY ${order} DESC)`);
-					query.append(' UNION ');
-					query.append('(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) ');
-					query.append(SQL`WHERE private = ${isPrivate} AND p1id = ${userid2} AND p2id = ${userid} `);
-					query.append(`ORDER BY ${order} DESC)`);
-					query.append(` ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
-					return replays.query(query);
+					return replays.query(SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
+						FORCE INDEX (p1) 
+						WHERE private = ${isPrivate} AND p1id = ${userid} AND p2id = ${userid2}
+						 ORDER BY ${order} DESC)
+						 UNION 
+						(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) 
+						WHERE private = ${isPrivate} AND p1id = ${userid2} AND p2id = ${userid} 
+						ORDER BY ${order} DESC)
+						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
 				}
 			} else {
 				if (format) {
-					const query = SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays `;
-					query.append(`FORCE INDEX (p1) `);
-					query.append(SQL`WHERE private = ${isPrivate} AND p1id = ${userid} AND format = ${format} `);
-					query.append(`ORDER BY ${order} DESC) `);
-					query.append(' UNION ');
-					query.append('(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2)');
-					query.append(SQL` WHERE private = ${isPrivate} AND p2id = ${userid} AND format = ${format} `);
-					query.append(`ORDER BY ${order} DESC)`);
-					query.append(SQL` ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
-					return replays.query(query);
+					return replays.query(SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
+						FORCE INDEX (p1) 
+						WHERE private = ${isPrivate} AND p1id = ${userid} AND format = ${format} 
+						ORDER BY ${order} DESC) 
+						 UNION 
+						(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2)
+						 WHERE private = ${isPrivate} AND p2id = ${userid} AND format = ${format} 
+						ORDER BY ${order} DESC)
+						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
 				} else {
-					const query = SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays `;
-					query.append(`FORCE INDEX (p1) `);
-					query.append(SQL`WHERE private = ${isPrivate} AND p1id = ${userid} ORDER BY ${order} DESC)`);
-					query.append(' UNION ');
-					query.append('(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) ');
-					query.append(SQL`WHERE private = ${isPrivate} AND p2id = ${userid} ORDER BY ${order} DESC)`);
-					query.append(SQL` ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
-					return replays.query(query);
+					return replays.query(SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
+						FORCE INDEX (p1) 
+						WHERE private = ${isPrivate} AND p1id = ${userid} ORDER BY ${order} DESC)
+						 UNION 
+						(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) 
+						WHERE private = ${isPrivate} AND p2id = ${userid} ORDER BY ${order} DESC)
+						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
 				}
 			}
 		}
 
 		if (args.byRating) {
-			const query = SQL`SELECT uploadtime, id, format, p1, p2, rating, password `;
-			query.append(`FROM ps_replays FORCE INDEX (top) `);
-			query.append(SQL`WHERE private = ${isPrivate} AND formatid = ${format} ORDER BY rating DESC LIMIT 51`);
-			return replays.query(query);
+			return replays.query(SQL`SELECT uploadtime, id, format, p1, p2, rating, password 
+				FROM ps_replays FORCE INDEX (top) 
+				WHERE private = ${isPrivate} AND formatid = ${format} ORDER BY rating DESC LIMIT ${limit1}, 51`);
 		} else {
-			const query = SQL`SELECT uploadtime, id, format, p1, p2, rating, password `;
-			query.append(`FROM ps_replays FORCE INDEX (format) `);
-			query.append(SQL`WHERE private = ${isPrivate} AND formatid = ${format} ORDER BY rating DESC LIMIT 51`);
-			return replays.query(query);
+			return replays.query(SQL`SELECT uploadtime, id, format, p1, p2, rating, password 
+				FROM ps_replays FORCE INDEX (format) 
+				WHERE private = ${isPrivate} AND formatid = ${format} ORDER BY uploadtime DESC LIMIT ${limit1}, 51`);
 		}
 	}
 
@@ -204,22 +198,19 @@ export const Replays = new class {
 		});
 		if (patterns.length !== 1 && patterns.length !== 2) return [];
 
-		const query = SQL`SELECT /*+ MAX_EXECUTION_TIME(10000) */ `;
-		query.append(`uploadtime, id, format, p1, p2, password FROM ps_replays `);
-		query.append(SQL`FORCE INDEX (recent) WHERE private = 0 AND log LIKE ${patterns[0]} `);
-		if (patterns.length === 2) {
-			query.append(SQL`AND log LIKE ${patterns[1]} `);
-		}
-		query.append(`ORDER BY uploadtime DESC LIMIT 10;`);
+		const secondPattern = patterns.length >= 2 ? SQL`AND log LIKE ${patterns[1]} ` : undefined;
 
-		return replays.query(query);
+		return replays.query(SQL`SELECT /*+ MAX_EXECUTION_TIME(10000) */ 
+			uploadtime, id, format, p1, p2, password FROM ps_replays 
+			FORCE INDEX (recent) WHERE private = 0 AND log LIKE ${patterns[0]} ${secondPattern}
+			ORDER BY uploadtime DESC LIMIT 10;`);
 	}
 
 	async recent() {
-		const query = SQL`SELECT uploadtime, id, format, p1, p2 FROM ps_replays `;
-		query.append(`FORCE INDEX (recent) WHERE private = 0 ORDER BY uploadtime `);
-		query.append('DESC LIMIT 50');
-		return replays.query(query);
+		return replays.selectAll(
+			SQL`uploadtime, id, format, p1, p2`,
+			SQL`FORCE INDEX (recent) WHERE private = 0 ORDER BY uploadtime DESC LIMIT 50`
+		);
 	}
 
 	normalizeUsername(username: string) {
@@ -280,17 +271,16 @@ export const Replays = new class {
 
 		const privacy = preppedReplay.private ? 1 : 0;
 		const {p1, p2, format, uploadtime, rating, inputlog} = preppedReplay;
-		const onDupe = SQL`ON DUPLICATE KEY UPDATE log = ${params.log as string}, `;
-		onDupe.append(SQL`inputlog = ${inputlog}, rating = ${rating}, `);
-		onDupe.append(SQL` private = ${privacy}, \`password\` = ${password}`);
 		await replays.insert({
 			id, p1, p2, format, p1id, p2id,
 			formatid, uploadtime,
 			private: privacy, rating, log,
 			inputlog, password,
-		}, onDupe, false);
+		}, SQL`ON DUPLICATE KEY UPDATE log = ${params.log as string},
+			inputlog = ${inputlog}, rating = ${rating},
+			private = ${privacy}, \`password\` = ${password}`);
 
-		await prepreplays.deleteOne(SQL`id = ${id} AND loghash = ${preppedReplay.loghash}`);
+		await prepreplays.deleteOne(SQL`WHERE id = ${id} AND loghash = ${preppedReplay.loghash}`);
 
 		return 'success:' + fullid;
 	}

--- a/src/replays.ts
+++ b/src/replays.ts
@@ -131,7 +131,7 @@ export const Replays = new class {
 			if (args.username2) {
 				const userid2 = toID(args.username2);
 				if (format) {
-					return replays.query(SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
+					return replays.query()`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
 						FORCE INDEX (p1) 
 						WHERE private = ${isPrivate} AND p1id = ${userid} 
 						AND p2id = ${userid2} AND format = ${format} 
@@ -143,9 +143,9 @@ export const Replays = new class {
 						WHERE private = ${isPrivate} AND p1id = ${userid2} AND p2id = ${userid} 
 						AND format = ${format}
 						 ORDER BY ${order} DESC)
-						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
+						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`;
 				} else {
-					return replays.query(SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
+					return replays.query()`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
 						FORCE INDEX (p1) 
 						WHERE private = ${isPrivate} AND p1id = ${userid} AND p2id = ${userid2}
 						 ORDER BY ${order} DESC)
@@ -153,11 +153,11 @@ export const Replays = new class {
 						(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) 
 						WHERE private = ${isPrivate} AND p1id = ${userid2} AND p2id = ${userid} 
 						ORDER BY ${order} DESC)
-						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
+						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`;
 				}
 			} else {
 				if (format) {
-					return replays.query(SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
+					return replays.query()`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
 						FORCE INDEX (p1) 
 						WHERE private = ${isPrivate} AND p1id = ${userid} AND format = ${format} 
 						ORDER BY ${order} DESC) 
@@ -165,27 +165,27 @@ export const Replays = new class {
 						(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2)
 						 WHERE private = ${isPrivate} AND p2id = ${userid} AND format = ${format} 
 						ORDER BY ${order} DESC)
-						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
+						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`;
 				} else {
-					return replays.query(SQL`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
+					return replays.query()`(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays 
 						FORCE INDEX (p1) 
 						WHERE private = ${isPrivate} AND p1id = ${userid} ORDER BY ${order} DESC)
 						 UNION 
 						(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) 
 						WHERE private = ${isPrivate} AND p2id = ${userid} ORDER BY ${order} DESC)
-						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`);
+						 ORDER BY ${order} DESC LIMIT ${limit1}, 51;`;
 				}
 			}
 		}
 
 		if (args.byRating) {
-			return replays.query(SQL`SELECT uploadtime, id, format, p1, p2, rating, password 
+			return replays.query()`SELECT uploadtime, id, format, p1, p2, rating, password 
 				FROM ps_replays FORCE INDEX (top) 
-				WHERE private = ${isPrivate} AND formatid = ${format} ORDER BY rating DESC LIMIT ${limit1}, 51`);
+				WHERE private = ${isPrivate} AND formatid = ${format} ORDER BY rating DESC LIMIT ${limit1}, 51`;
 		} else {
-			return replays.query(SQL`SELECT uploadtime, id, format, p1, p2, rating, password 
+			return replays.query()`SELECT uploadtime, id, format, p1, p2, rating, password 
 				FROM ps_replays FORCE INDEX (format) 
-				WHERE private = ${isPrivate} AND formatid = ${format} ORDER BY uploadtime DESC LIMIT ${limit1}, 51`);
+				WHERE private = ${isPrivate} AND formatid = ${format} ORDER BY uploadtime DESC LIMIT ${limit1}, 51`;
 		}
 	}
 
@@ -200,17 +200,16 @@ export const Replays = new class {
 
 		const secondPattern = patterns.length >= 2 ? SQL`AND log LIKE ${patterns[1]} ` : undefined;
 
-		return replays.query(SQL`SELECT /*+ MAX_EXECUTION_TIME(10000) */ 
+		return replays.query()`SELECT /*+ MAX_EXECUTION_TIME(10000) */ 
 			uploadtime, id, format, p1, p2, password FROM ps_replays 
 			FORCE INDEX (recent) WHERE private = 0 AND log LIKE ${patterns[0]} ${secondPattern}
-			ORDER BY uploadtime DESC LIMIT 10;`);
+			ORDER BY uploadtime DESC LIMIT 10;`;
 	}
 
 	async recent() {
 		return replays.selectAll(
-			SQL`uploadtime, id, format, p1, p2`,
-			SQL`FORCE INDEX (recent) WHERE private = 0 ORDER BY uploadtime DESC LIMIT 50`
-		);
+			SQL`uploadtime, id, format, p1, p2`
+		)`FORCE INDEX (recent) WHERE private = 0 ORDER BY uploadtime DESC LIMIT 50`;
 	}
 
 	normalizeUsername(username: string) {
@@ -280,7 +279,7 @@ export const Replays = new class {
 			inputlog = ${inputlog}, rating = ${rating},
 			private = ${privacy}, \`password\` = ${password}`);
 
-		await prepreplays.deleteOne(SQL`WHERE id = ${id} AND loghash = ${preppedReplay.loghash}`);
+		await prepreplays.deleteOne()`WHERE id = ${id} AND loghash = ${preppedReplay.loghash}`;
 
 		return 'success:' + fullid;
 	}

--- a/src/test/actions.test.ts
+++ b/src/test/actions.test.ts
@@ -76,7 +76,7 @@ describe('Loginserver actions', () => {
 
 	it('Should prepare replays', async () => {
 		// clear old
-		await tables.prepreplays.deleteOne(SQL`id = ${'gen8randombattle-3096'}`);
+		await tables.prepreplays.delete('gen8randombattle-3096');
 
 		// as long as it doesn't throw, we're fine
 		await utils.testDispatcher({
@@ -132,7 +132,7 @@ describe('Loginserver actions', () => {
 			const p2 = NTBBLadder.getUserData('catra')!;
 			for (const player of [p1, p2]) {
 				await tables.ladder.deleteAll(
-					SQL`userid = ${player.id} AND formatid = ${ladder.formatid}`,
+					SQL`WHERE userid = ${player.id} AND formatid = ${ladder.formatid}`,
 				);
 			}
 			await ladder.updateRating(p1, p2, 1);

--- a/src/test/actions.test.ts
+++ b/src/test/actions.test.ts
@@ -109,9 +109,8 @@ describe('Loginserver actions', () => {
 	describe('Ladder', () => {
 		it('Should update the ladder', async () => {
 			for (const id of ['catra', 'adora']) {
-				await tables.ladder.deleteOne(
-					SQL`userid = ${id} AND formatid = ${'gen1randombattle'}`,
-				); // clear their ratings entirely
+				// clear their ratings entirely
+				await tables.ladder.deleteOne()`userid = ${id} AND formatid = ${'gen1randombattle'}`;
 			}
 			const {result} = await utils.testDispatcher({
 				act: 'ladderupdate',
@@ -131,9 +130,7 @@ describe('Loginserver actions', () => {
 			const p1 = NTBBLadder.getUserData('shera')!;
 			const p2 = NTBBLadder.getUserData('catra')!;
 			for (const player of [p1, p2]) {
-				await tables.ladder.deleteAll(
-					SQL`WHERE userid = ${player.id} AND formatid = ${ladder.formatid}`,
-				);
+				await tables.ladder.deleteAll()`WHERE userid = ${player.id} AND formatid = ${ladder.formatid}`;
 			}
 			await ladder.updateRating(p1, p2, 1);
 			const {result} = await utils.testDispatcher({

--- a/src/test/replays.test.ts
+++ b/src/test/replays.test.ts
@@ -24,7 +24,7 @@ import * as utils from './test-utils';
 		});
 
 		const currentUnixTime = Math.floor(Date.now() / 1000);
-		const dbResult = await prepreplays.selectOne(null, SQL`p1 = ${'annika'} AND p2 = ${'heartofetheria'}`);
+		const dbResult = await prepreplays.selectOne(null, SQL`WHERE p1 = ${'annika'} AND p2 = ${'heartofetheria'}`);
 		assert(dbResult, 'database entry should exist');
 
 		assert.equal(dbResult.id, 'gen8randombattle-42');

--- a/src/test/replays.test.ts
+++ b/src/test/replays.test.ts
@@ -24,7 +24,7 @@ import * as utils from './test-utils';
 		});
 
 		const currentUnixTime = Math.floor(Date.now() / 1000);
-		const dbResult = await prepreplays.selectOne(null, SQL`WHERE p1 = ${'annika'} AND p2 = ${'heartofetheria'}`);
+		const dbResult = await prepreplays.selectOne()`WHERE p1 = ${'annika'} AND p2 = ${'heartofetheria'}`;
 		assert(dbResult, 'database entry should exist');
 
 		assert.equal(dbResult.id, 'gen8randombattle-42');


### PR DESCRIPTION
This commit adds a new SQL tagged template string syntax way more powerful than the old one.

After discussion on Discord, I realized that requiring tagged template strings and completely disallowing raw strings as SQL would make the code a lot safter, but tagged template strings just needed a bit more work to make them bearable for this purpose. I've now implemented said tagged template strings.

Documentation in the jsdoc above the SQL tag function.