### PR TITLE
Ladder: Add missing truncation/bounding

### DIFF
--- a/src/ladder.ts
+++ b/src/ladder.ts
@@ -46,11 +46,11 @@ export class Ladder {
 		this.rpoffset = 9 * 60 * 60;
 	}
 	getRP() {
-		const rpnum = ((time() - this.rpoffset) / this.rplen) + 1;
+		const rpnum = Math.trunc((time() - this.rpoffset) / this.rplen) + 1;
 		return rpnum * this.rplen + this.rpoffset;
 	}
 	nextRP(rp: number) {
-		const rpnum = (rp / this.rplen);
+		const rpnum = Math.trunc(rp / this.rplen);
 		return (rpnum + 1) * this.rplen + this.rpoffset;
 	}
 	clearRating(name: string) {


### PR DESCRIPTION
Changes are based upon https://gist.github.com/scheibo/68c1822dcae79e11be5845b5abec9025

Timestamp numbers were not being properly truncated for rating periods. Without truncation, first time players' rating would always change immediately after their second battle ended since the rating period is determined by the current time (which would be the time of the first battle).