### PR TITLE
Update jquery

### DIFF
--- a/src/public/oauth-authorize.html
+++ b/src/public/oauth-authorize.html
@@ -103,7 +103,7 @@
 		}
 
 		var jqueryEl = document.createElement('script');
-		jqueryEl.src = '/js/lib/jquery-2.1.4.min.js';
+		jqueryEl.src = '/js/lib/jquery-2.2.4.min.js';
 		jqueryEl.onload = function() {
 			if (!params.get('token')) {
 				$('#auth').on('click', () => { // this should send a req to get a token


### PR DESCRIPTION
We don't have jquery 2.1.4 anymore, apparently

To elaborate a bit more, we used to host a 2.1.4 version here https://play.pokemonshowdown.com/js/lib/ but now that one is updated and the reference in this file is stale