### PR TITLE
Fix player name length check in `addreplay` action

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -189,8 +189,8 @@ export const actions: {[k: string]: QueryHandler} = {
 			throw new ActionError("Required params: id, format, log, players", 400);
 		}
 		// player usernames cannot be longer than 18 characters
-		if (!params.players.split(',').some(p => p.length > 18)) {
-			throw new ActionError("Player names much be 18 chars or shorter", 400);
+		if (params.players.split(',').some(p => p.length > 18)) {
+			throw new ActionError("Player names must be 18 chars or shorter", 400);
 		}
 		// the battle ID must be valid
 		// the format from the battle ID must match the format ID


### PR DESCRIPTION
I'm unsure if this is the only issue with side server replays. Currently, if I send 2 player names both with a length of 19, the proper replay id is sent back, but I couldn't see it until I set `hidden` to 2 (see https://replay.pokemonshowdown.com/dl-gen9paldeadexdraft-1, the battle was originally not private on the server)