### PR TITLE
Set up Docker env for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.build
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .eslintcache
 config/*
 .DS_Store
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
+
+ARG NODE_VERSION=20.10.0
+
+################################################################################
+# Use node image for base image for all stages.
+FROM node:${NODE_VERSION}-alpine as base
+
+# Set working directory for all build stages.
+WORKDIR /usr/src/app
+
+
+################################################################################
+# Create a stage for installing production dependecies.
+FROM base as deps
+
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /root/.npm to speed up subsequent builds.
+# Leverage bind mounts to package.json and package-lock.json to avoid having to copy them
+# into this layer.
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=package-lock.json,target=package-lock.json \
+    --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev
+
+################################################################################
+# Create a stage for building the application.
+FROM deps as build
+
+# Download additional development dependencies before building, as some projects require
+# "devDependencies" to be installed to build. If you don't need this, remove this step.
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=package-lock.json,target=package-lock.json \
+    --mount=type=cache,target=/root/.npm \
+    npm ci
+
+# Copy the rest of the source files into the image.
+COPY . .
+
+# Run the build script.
+RUN npm run build
+
+################################################################################
+# Create a new stage to run the application with minimal runtime dependencies
+# where the necessary files are copied from the build stage.
+FROM base as final
+
+# Use production node environment by default.
+ENV NODE_ENV production
+
+# Run the application as a non-root user.
+USER node
+
+# Copy package.json so that package manager commands can be used.
+COPY package.json .
+
+# Copy the production dependencies from the build stage and also
+# the built application from the build stage into the image.
+COPY --from=build /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/.dist ./.dist
+
+# Use default configuration files for loginserver
+ADD config/pm2-example.js ./config/pm2.config.js
+ADD config/config-example.js ./config/config.js
+
+# Add some necessary source files
+ADD src/public ./src/public
+
+# Expose the port that the application listens on.
+EXPOSE 8080
+
+# Run the application.
+CMD npm run start-on-docker && npx pm2 logs

--- a/Dockerfile.replays
+++ b/Dockerfile.replays
@@ -1,0 +1,5 @@
+FROM cockroachdb/cockroach:latest as base
+COPY src/schemas/replays.sql /docker-entrypoint-initdb.d/replays.sql
+# CockroachDB listens on port 26257. Overwrite default EXPOSE that also exposes 8080
+# EXPOSE 26257
+CMD ["start-single-node", "--insecure"]

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,22 @@
+### Building and running your application
+
+When you're ready, start your application by running:
+`docker compose up --build`.
+
+Your application will be available at http://localhost:8080.
+
+### Deploying your application to the cloud
+
+First, build your image, e.g.: `docker build -t myapp .`.
+If your cloud uses a different CPU architecture than your development
+machine (e.g., you are on a Mac M1 and your cloud provider is amd64),
+you'll want to build the image for that platform, e.g.:
+`docker build --platform=linux/amd64 -t myapp .`.
+
+Then, push it to your registry, e.g. `docker push myregistry.com/myapp`.
+
+Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
+docs for more detail on building and pushing.
+
+### References
+* [Docker's Node.js guide](https://docs.docker.com/language/nodejs/)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,24 @@
+services:
+  pokemon-showdown-loginserver:
+    build:
+      context: .
+    environment:
+      NODE_ENV: production
+    ports:
+      - 8080:8080
+    depends_on:
+      replay-db:
+        condition: service_started
+    develop:
+      watch:
+        - action: rebuild
+          path: .
+  replay-db:
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile.replays
+    develop:
+      watch:
+        - action: rebuild
+          path: src/schemas

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npx tsc",
     "run": "npx tsc && node .dist/src/",
     "start": "npx tsc && npx pm2 start config/pm2.js",
+    "start-on-docker": "npx pm2 start config/pm2.config.js",
     "test": "npm run lint && npx tsc",
     "reload": "npx tsc && npx pm2 reload config/pm2.js",
     "stop": "npx pm2 stop config/pm2.js"

--- a/src/schemas/replays.sql
+++ b/src/schemas/replays.sql
@@ -31,5 +31,5 @@ CREATE TABLE public.replays (
 	INDEX private_uploadtime (private ASC, uploadtime ASC),
 	INDEX private_formatid_uploadtime (private ASC, formatid ASC, uploadtime ASC),
 	INDEX private_formatid_rating (private ASC, formatid ASC, rating ASC),
-	INVERTED INDEX log (log)
+	INVERTED INDEX log (log gin_trgm_ops)
 );


### PR DESCRIPTION
This PR adds a docker files and compose spec, to enable quickly setting up a dev environment for loginserver testing.
Right now, it starts a loginserver instance, mapping port 8080 on the container to the host, along with a cockroachdb instance.

By running `docker compose up --build --watch` you will build and start both services and can monitor their combined logs on the console. Changing the source files will trigger a rebuild (aka hot reloading).