### PR TITLE
Add a rating request for Elo+Glicko format-specific data

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -470,6 +470,21 @@ export const actions: {[k: string]: QueryHandler} = {
 		return rating?.elo || 1000;
 	},
 
+	async rating(params) {
+		const server = await this.getServer(true);
+		if (server?.id !== Config.mainserver) {
+			// legacy error
+			return {errorip: "This ladder is not for your server. You should turn off Config.remoteladder."};
+		}
+		if (!toID(params.format)) throw new ActionError("Specify a format.");
+		const ladder = new Ladder(params.format!);
+		if (!Ladder.isValidPlayer(params.user)) return {elo: 1000, rpr: 1500, rprd: 130};
+
+		const rating = await ladder.getRating(params.user!);
+		if (!rating) return {elo: 1000, rpr: 1500, rprd: 130};
+		return {elo: rating.elo, rpr: rating.rpr, rprd: rating.rprd};
+	},
+
 	async restart() {
 		await this.requireMainServer();
 


### PR DESCRIPTION
This can be used as backing to implement placements matchmaking. Placements mechanism are a discrete mechanism, while Glicko-2 provides the data required as a continuum.

See PR thread, shut down prematurely due to supposed technical infeasibility.

https://www.smogon.com/forums/threads/placement-matchmaking-to-preventing-ladder-smurfing.3751632/

My initial intent is to keep the ladder points and sorting Elo-based (with all its current mechanisms, 1000 floor and decay), but move matchmaking to Glicko-2.

Matchmaking would get a new requirement: candidate players must be both below XOR above an arbitrary RPRD threshold (this can well match the current "provisional" rating threshold, which is 100).