### PR TITLE
feat(server): Allow binding to more than localhost

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -134,6 +134,13 @@ exports.crashguardemail = null;
 exports.ssl = null;
 
 /**
+ * Address to bind to.
+ *   This should be kept set to '127.0.0.1' unless you know what you're doing.
+ * @type {string}
+ */
+exports.bindaddress = '127.0.0.1';
+
+/**
  * Port to listen on.
  * @type {number}
  */

--- a/src/server.ts
+++ b/src/server.ts
@@ -324,15 +324,17 @@ export const SimServers = new class SimServersT {
 export class Server {
 	server: http.Server;
 	httpsServer: https.Server | null;
+	host: string;
 	port: number;
 	awaitingEnd?: () => void;
 	closing?: Promise<void>;
 	activeRequests = 0;
-	constructor(port = (Config.port || 8000)) {
+	constructor(host = (Config.bindaddress || "127.0.0.1"), port = (Config.port || 8000)) {
+		this.host = host;
 		this.port = port;
 
 		this.server = http.createServer((req, res) => void this.handle(req, res));
-		this.server.listen(port);
+		this.server.listen(port, host);
 		this.httpsServer = null;
 		if (Config.ssl) {
 			this.httpsServer = https.createServer(Config.ssl, (req, res) => void this.handle(req, res));


### PR DESCRIPTION
*Should* keep the old behavior intact?