### PR TITLE
 Assign loadServers() result in watchFile callback

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -265,7 +265,7 @@ export const SimServers = new class SimServersT {
 	constructor() {
 		fs.watchFile(Config.serverlist, (curr, prev) => {
 			if (curr.mtime > prev.mtime) {
-				this.loadServers();
+				this.servers = this.loadServers();
 			}
 		});
 	}


### PR DESCRIPTION
`loadServers()` was called in the `watchFile` callback but its return value was never assigned to `this.servers`, so any changes to `Config.serverlist` (new registrations, token updates) were silently ignored at runtime. This caused side servers to disappear from the server list and broke replay uploads until the login server was manually rebooted.