### PR TITLE
Add OAuth page login form

### DIFF
--- a/src/public/oauth-authorize.html
+++ b/src/public/oauth-authorize.html
@@ -25,7 +25,20 @@
 
 		<div class="main"><section class="section">
 			<h2>Authorize {{client}}</h2><hr />
-			<div class="infobox" id="authpanel">
+			<div class="infobox" id="loginpanel" style="display:none">
+				<p id="loginerror" class="error" role="alert" style="color:red;display:none"></p>
+				<p>Log in to authorize {{client}}.</p>
+				<form id="loginform">
+					<p><label class="label">Username:<br />
+						<input class="textbox" type="text" name="name" autocomplete="username" required />
+					</label></p>
+					<p><label class="label">Password:<br />
+						<input class="textbox" type="password" name="pass" autocomplete="current-password" required />
+					</label></p>
+					<p class="buttonbar"><button id="login" class="button greenbutton" type="submit">Log in</button></p>
+				</form>
+			</div>
+			<div class="infobox" id="authpanel" style="display:none">
 				{{client}} by {{client_name}} wants to access your Pokemon Showdown account<span id="username"></span>.<br />
 				This does not expose any private information, and will allow you to log in on their site using your Pokemon Showdown account for two weeks.<br /><br /><hr />
 				<a id="auth" class="button greenbutton nav-first nav-last">Authorize</a><br /><br />
@@ -56,20 +69,11 @@
 		var tokenName = 'ps-' + params.get('client_id') + "-token";
 		var token = localStorage.getItem(tokenName);
 		var authorizedUser = '';
-		var username = document.cookie
-			.split('; ')
-			.filter(x => x.startsWith('showdown_username'))
-			.map(x => x.split('=').slice(1).join('='))[0];
-		if (!username) {
-			alert("Please log in on Pokemon Showdown before using this page.");
-			throw '';
-		} else {
-			document.getElementById('username').innerText = ` (logged in as "${decodeURI(username)}")`;
-		}
-		if (token) {
-			params.set('token', token);
-		}
 		var acting = false;
+
+		function setUsername(username) {
+			document.getElementById('username').innerText = ` (logged in as "${username}")`;
+		}
 
 		function getAssertion() {
 			$.get('/api/oauth/api/getassertion', {
@@ -125,19 +129,69 @@
 			}));
 		}
 
-		var jqueryEl = document.createElement('script');
-		jqueryEl.src = '/js/lib/jquery-2.2.4.min.js';
-		jqueryEl.onload = function() {
-			if (!params.get('token')) {
-				$('#auth').on('click', () => {
+		function showLogin(error) {
+			$('#authpanel').css({display: 'none'});
+			$('#loginpanel').css({display: ''});
+			if (error) {
+				$('#loginerror').text(error).css({display: ''});
+			} else {
+				$('#loginerror').css({display: 'none'});
+			}
+		}
+
+		function setupAuthorization(useStoredToken) {
+			$('#loginpanel').css({display: 'none'});
+			$('#authpanel').css({display: ''});
+			if (useStoredToken && token) {
+				params.set('token', token);
+				$('#authpanel').css({display: 'none'});
+				getAssertion();
+			} else {
+				params.delete('token');
+				localStorage.removeItem(tokenName);
+				$('#auth').off('click').on('click', () => {
 					if (acting) return;
 					acting = true;
 					authorize();
 				});
-			} else {
-				$('#authpanel').css({display: 'none'});
-				getAssertion();
 			}
+		}
+
+		function checkLogin(error, useStoredToken = true) {
+			$.get('/api/oauth/api/authorized', safeJSON(function (data) {
+				if (data.username) {
+					setUsername(data.username);
+					setupAuthorization(useStoredToken);
+				} else {
+					showLogin(error);
+				}
+			})).fail(function () {
+				showLogin('The loginserver could not check your session. Please try again.');
+			});
+		}
+
+		var jqueryEl = document.createElement('script');
+		jqueryEl.src = '/js/lib/jquery-2.2.4.min.js';
+		jqueryEl.onload = function() {
+			$('#loginform').on('submit', function (event) {
+				event.preventDefault();
+				if (acting) return;
+				acting = true;
+				$('#login').prop('disabled', true).text('Logging in...');
+				$.post('/api/login', {
+					name: this.elements['name'].value,
+					pass: this.elements['pass'].value,
+				}, safeJSON(function (data) {
+					acting = false;
+					$('#login').prop('disabled', false).text('Log in');
+					if (!data.actionsuccess || !data.curuser || !data.curuser.username) {
+						showLogin(data.actionerror || 'Wrong username or password.');
+						return;
+					}
+					checkLogin('Log in with a registered account.', false);
+				}));
+			});
+			checkLogin();
 		}
 		document.body.appendChild(jqueryEl);
 

--- a/src/test/oauth.test.ts
+++ b/src/test/oauth.test.ts
@@ -160,6 +160,8 @@ void suite('OAuth', () => {
 		const valid = await httpRequest(server, `/api/oauth/authorize?${validParams}`);
 		assert.equal(valid.statusCode, 200);
 		assert.match(valid.body, /OAuth fixture A/);
+		assert.match(valid.body, /id="loginform"/);
+		assert.match(valid.body, /\$\.post\('\/api\/login'/);
 		assert.match(valid.body, /\$\.post\('\/api\/oauth\/api\/authorize'/);
 		assert.match(valid.body, /redirect\.searchParams\.set\('token', params\.get\('token'\)\)/);
 		assert.equal(valid.headers['access-control-allow-origin'], undefined);


### PR DESCRIPTION
Very simple UI to login directly if you aren't. Current behaviour is to send you an alert to go login

Current:

<img width="453" height="169" alt="Screenshot 2026-08-13 at 20 49 01" src="https://github.com/user-attachments/assets/0ad22bcf-721f-496b-9657-3933c4280893" />

This PR:

<img width="697" height="324" alt="Screenshot 2026-08-12 at 20 06 36" src="https://github.com/user-attachments/assets/48c790b6-6b62-445e-baa1-6af7a01edca5" />

and after you've logged in

<img width="697" height="425" alt="Screenshot 2026-08-12 at 20 06 44" src="https://github.com/user-attachments/assets/1c691b89-556b-4073-ae6c-228df60b632c" />

if you mess it up

<img width="699" height="702" alt="Screenshot 2026-08-13 at 21 53 04" src="https://github.com/user-attachments/assets/66b406f1-0f84-4c67-9fa6-d6a6f4b706ec" />
